### PR TITLE
ignoring contentassets in uninstall_packaged_incremental

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -42,8 +42,10 @@ tasks:
 
     uninstall_packaged_incremental:
         options:
-            ignore_types:
-                - ContentAsset
+            ignore:
+                ContentAsset:
+                    - HIVE_Foundation_hero
+                    - HIVE_Foundation_logo
 
     # Fundseeker customer enablement
     fundseeker_create_site:


### PR DESCRIPTION
Prevents uninstall of ContentAsset files in `uninstall_packaged_incremental` that are an unpackaged dependency in packaging org
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
- [ ] ~Any net new LWC work has JEST test coverage 50% or above~
- [ ] ~Default Sa11y tests pass for all LWC components~
- [ ] ~🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary~
- [ ] ~🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary~
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [ ] ~Make sure that ACs are updated (if any gaps)~
- [ ] **All acceptance criteria have been met**
    - [ ] Developer
    - [ ] Code Reviewer
- [ ] ~Pull Request contains draft release notes~
- [ ] ~Labels, help text, and customer facing messages are reviewed by Docs~
- [ ] ~QE story level testing completed~
