### PR TITLE
W-9188071 - Regression test fix - Swap 'release.json' edition to Developer

### DIFF
--- a/orgs/release.json
+++ b/orgs/release.json
@@ -1,6 +1,6 @@
 {
   "orgName": "Outbound Funds Community - Release Test Org",
-  "edition": "Enterprise",
+  "edition": "Developer",
   "features": ["Communities"],
   "settings": {
     "lightningExperienceSettings": {


### PR DESCRIPTION
Error: During the `regression_org` flow on a release org shape, `deploy_post` was failing due to the lack of the 'Customer Community User Plus Login` value to assign to the `userlicense` attribute in the `Fundseeker Plus Login` profile.

Fix: Update the `release.json` org shape `"edition"` to 'Developer' from 'Enterprise'
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
-~ [ ] Any net new LWC work has JEST test coverage 50% or above~
- ~[ ] Default Sa11y tests pass for all LWC components~
- ~[ ] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary~
- ~[ ] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- ~[ ] Make sure that ACs are updated (if any gaps)~
- ~[ ] Add Open Source short version license if new files suppport inline comments. For more information check SHORT_VERSION_LICENSE_GUIDELINES readme.~
- [ ] **All acceptance criteria have been met**
    - [x] Developer
    - [x] Code Reviewer
- [x] Pull Request contains draft release notes
- ~[ ] Labels, help text, and customer facing messages are reviewed by Docs~
- [ ] QE story level testing completed
