### PR TITLE
W-9199646 - Add prerelease org declarations to cumulusci

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -21,6 +21,12 @@ project:
         repo_url: "https://github.com/SalesforceFoundation/OutboundFundsModuleSite"
     source_format: sfdx
 
+orgs:
+    scratch:
+        prerelease:
+            config_file: orgs/prerelease.json
+        beta_prerelease:
+            config_file: orgs/beta_prerelease.json
 tasks:
     # Automerge Major Release Branches
     github_automerge_feature:


### PR DESCRIPTION
Fix for the error: 
`Error: No scratch org config named prerelease found in the cumulusci.yml file`

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
- [ ] ~Any net new LWC work has JEST test coverage 50% or above~
- [ ] ~Default Sa11y tests pass for all LWC components~
- [ ] ~🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary~
- [ ] ~🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [x] Make sure that ACs are updated (if any gaps)
- [ ] ~Add Open Source short version license if new files suppport inline comments. For more information check SHORT_VERSION_LICENSE_GUIDELINES readme.~
- [x] **All acceptance criteria have been met**
    - [x] Developer
    - [x] Code Reviewer
- ~[ ] Pull Request contains draft release notes~
- ~[ ] Labels, help text, and customer facing messages are reviewed by Docs~
- ~[ ] QE story level testing completed~
