### PR TITLE
Add quick action buttons to page layouts on qa_org and dev_org flows

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -3,7 +3,7 @@
 # * SPDX-License-Identifier: BSD-3-Clause
 # * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 # *
-minimum_cumulusci_version: "3.32.0"
+minimum_cumulusci_version: "3.34.1"
 project:
     name: OutboundFundsCommunity
     package:
@@ -280,6 +280,36 @@ tasks:
             network_name: Fundseeker Portal
             navigation_menu: OFM_Portal_Navigation1
 
+    add_apply_quick_action_to_funding_program_layout:
+        group: "OFM-Site: Fundseeker customer enablement"
+        description: Adds the Apply quick action to the Funding Program Experience Site layout.
+        class_path: cumulusci.tasks.metadata_etl.layouts.AddRecordPlatformActionListItem
+        options:
+            api_names: "outfunds__Funding_Program__c-%%%NAMESPACE%%%OFM Funding Program Site Layout"
+            action_name: "outfunds__Funding_Program__c.Apply"
+            action_type: QuickAction
+            place_first: true
+
+    add_submit_quick_action_to_requirement_layout:
+        group: "OFM-Site: Fundseeker customer enablement"
+        description: Adds the Submit quick action to the Requirement Experience Site layout.
+        class_path: cumulusci.tasks.metadata_etl.layouts.AddRecordPlatformActionListItem
+        options:
+            api_names: "outfunds__Requirement__c-%%%NAMESPACE%%%OFM Requirement Site Layout"
+            action_name: "outfunds__Requirement__c.Submit"
+            action_type: QuickAction
+            place_first: true
+
+    add_submit_application_quick_action_to_funding_request_layout:
+        group: "OFM-Site: Fundseeker customer enablement"
+        description: Adds the Submit quick action to the Funding Request Experience Site layout.
+        class_path: cumulusci.tasks.metadata_etl.layouts.AddRecordPlatformActionListItem
+        options:
+            api_names: "outfunds__Funding_Request__c-%%%NAMESPACE%%%OFM Funding Request Site Layout"
+            action_name: "outfunds__Funding_Request__c.SubmitApplication"
+            action_type: QuickAction
+            place_first: true
+
 flows:
     # dev story
     dev_story:
@@ -310,6 +340,12 @@ flows:
                 task: common_share_funding_programs_with_accounts_with_funding_requests
             11:
                 flow: common_replace_and_publish_theme_layout_navigation_menu
+            12:
+                task: add_apply_quick_action_to_funding_program_layout
+            13:
+                task: add_submit_quick_action_to_requirement_layout
+            14:
+                task: add_submit_application_quick_action_to_funding_request_layout
 
     config_dev:
         steps:
@@ -356,6 +392,12 @@ flows:
                 task: common_share_funding_programs_with_accounts_with_funding_requests
             11:
                 flow: common_replace_and_publish_theme_layout_navigation_menu
+            12:
+                task: add_apply_quick_action_to_funding_program_layout
+            13:
+                task: add_submit_quick_action_to_requirement_layout
+            14:
+                task: add_submit_application_quick_action_to_funding_request_layout
 
     config_qa:
         steps:


### PR DESCRIPTION
For the internal QA and Dev org flows, the following were added. They are not included in installer:
* Add Submit quick action button to Requirements page layout
* Add Apply quick action button to Funding Program page layout
* Add Submit Application quick action button to Funding Request page layout

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
- ~[ ] Any net new LWC work has JEST test coverage 50% or above~
- ~[ ] Default Sa11y tests pass for all LWC components~
- ~[ ] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary~
- ~[ ] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary~
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [ ] Make sure that ACs are updated (if any gaps)
- ~[ ] Add Open Source short version license if new files suppport inline comments. For more information check SHORT_VERSION_LICENSE_GUIDELINES readme.~
- [ ] **All acceptance criteria have been met**
    - [ ] Developer
    - [x] Code Reviewer
- [ ] Pull Request contains draft release notes
- [ ] Labels, help text, and customer facing messages are reviewed by Docs
- [x] QE story level testing completed
