### PR TITLE
W-9172859 - OFM Experience Template - Add task to installer to inject Funding Program 'Apply' and 'Submit' Requirement quickaction buttons and 'Submit Application 'Funding Request'

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -446,6 +446,21 @@ flows:
                 checks:
                     - when: "not tasks.fundseeker_check_sharing_set_owds()"
                       action: hide
+            6:
+                task: add_apply_quick_action_to_funding_program_layout
+                ui_options:
+                    name: "Add the 'Apply' Quick Action to the 'Funding Program Site Layout' page layout"
+                    is_required: True
+            7:
+                task: add_submit_quick_action_to_requirement_layout
+                ui_options:
+                    name: "Add the 'Submit' Quick Action to the 'Requirement Site Layout' page layout"
+                    is_required: True
+            8:
+                task: add_submit_application_quick_action_to_funding_request_layout
+                ui_options:
+                    name: "Add the 'Submit Application' Quick Action to the 'Funding Request Site Layout' page layout"
+                    is_required: True
 
     # Internal flows
     common_replace_and_publish_theme_layout_navigation_menu:


### PR DESCRIPTION
For the "OFM Fundseeker Starter Portal Template" installer, the plan "Install OFM Fundseeker Starter Portal Template and Build Site" now includes adding the following quick actions to page layouts:

Quick Action: Apply (outfunds__Funding_Program__c.Apply)
Page Layout: OFM Funding Program Site Layout (outfunds__Funding_Program__c-outfunds__OFM Funding Program Site Layout")

Quick Action: Submit (outfunds__Requirement__c.Submit)
Page Layout: OFM Requirement Site Layout (outfunds__Requirement__c-outfunds__OFM Requirement Site Layout")

Quick Action: Submit Application (outfunds__Funding_Request__c.SubmitApplication)
Page Layout: OFM Funding Request Site Layout (outfunds__Funding_Request__c-outfunds__OFM Funding Request Site Layout")

# Critical Changes

# Changes

- We updated the Outbound Funds Module Experience Site Template installer to add the following quick actions: _Apply_ to Funding Program, _Submit Application_ on a Funding Request, and _Submit_ a Requirement.


# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
~[ ] Any net new LWC work has JEST test coverage 50% or above~
~[ ] Default Sa11y tests pass for all LWC components~
~[ ] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary~
~[ ] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [ ] Make sure that ACs are updated (if any gaps)
~[ ] Add Open Source short version license if new files support inline comments. For more information check SHORT_VERSION_LICENSE_GUIDELINES readme.~
- [ ] **All acceptance criteria have been met**
    - [x] Developer
    - [ ] Code Reviewer
- [x] Pull Request contains draft release notes
- [x] Labels, help text, and customer facing messages are reviewed by Docs
- [x] QE story level testing completed
