### PR TITLE
W-10330211 Removing isotope dependency

### DIFF
--- a/force-app/main/default/layouts/outfunds__Disbursement__c-OFM Disbursement Site Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/outfunds__Disbursement__c-OFM Disbursement Site Layout.layout-meta.xml
@@ -11,7 +11,6 @@
     <excludeButtons>Clone</excludeButtons>
     <excludeButtons>Delete</excludeButtons>
     <excludeButtons>Edit</excludeButtons>
-    <excludeButtons>IsotopeSubscription</excludeButtons>
     <excludeButtons>Submit</excludeButtons>
     <layoutSections>
         <customLabel>false</customLabel>

--- a/force-app/main/default/layouts/outfunds__Funding_Program__c-OFM Funding Program Site Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/outfunds__Funding_Program__c-OFM Funding Program Site Layout.layout-meta.xml
@@ -11,7 +11,6 @@
     <excludeButtons>Clone</excludeButtons>
     <excludeButtons>Delete</excludeButtons>
     <excludeButtons>Edit</excludeButtons>
-    <excludeButtons>IsotopeSubscription</excludeButtons>
     <excludeButtons>Share</excludeButtons>
     <excludeButtons>Submit</excludeButtons>
     <layoutSections>

--- a/force-app/main/default/layouts/outfunds__Funding_Request__c-OFM Funding Request Site Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/outfunds__Funding_Request__c-OFM Funding Request Site Layout.layout-meta.xml
@@ -8,7 +8,6 @@
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
     <excludeButtons>ChangeOwnerOne</excludeButtons>
     <excludeButtons>ChangeRecordType</excludeButtons>
-    <excludeButtons>IsotopeSubscription</excludeButtons>
     <excludeButtons>Share</excludeButtons>
     <excludeButtons>Submit</excludeButtons>
     <layoutSections>

--- a/force-app/main/default/layouts/outfunds__Requirement__c-OFM Requirement Site Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/outfunds__Requirement__c-OFM Requirement Site Layout.layout-meta.xml
@@ -11,7 +11,6 @@
     <excludeButtons>Clone</excludeButtons>
     <excludeButtons>Delete</excludeButtons>
     <excludeButtons>Edit</excludeButtons>
-    <excludeButtons>IsotopeSubscription</excludeButtons>
     <excludeButtons>Share</excludeButtons>
     <excludeButtons>Submit</excludeButtons>
     <layoutSections>


### PR DESCRIPTION
[W-10330211](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000Yih5hYAB/view)

The following layouts no longer exclude the `IsotopeSubscription` button
to remove the dependency on Isotope being enabled for the org:
- `outfunds__Disbursement__c-OFM Disbursement Site Layout.layout-meta.xml`
- `outfunds__Funding_Program__c-OFM Funding Program Site Layout.layout-meta.xml`
- `outfunds__Funding_Request__c-OFM Funding Request Site Layout.layout-meta.xml`
- `outfunds__Requirement__c-OFM Requirement Site Layout.layout-meta.xml`

# Critical Changes

# Changes
The following layouts no longer exclude the `IsotopeSubscription` button:
- OFM Disbursement Site Layout
- OFM Funding Program Site Layout
- OFM Funding Request Site Layout
- OFM Requirement Site Layout

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
- [x] Any net new LWC work has JEST test coverage 50% or above
- [x] Default Sa11y tests pass for all LWC components
- [x] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary
- [x] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [x] Make sure that ACs are updated (if any gaps)
- [x] Add Open Source short version license if new files suppport inline comments. For more information check SHORT_VERSION_LICENSE_GUIDELINES readme.
- [ ] **All acceptance criteria have been met**
    - [x] Developer
    - [ ] Code Reviewer
- [x] Pull Request contains draft release notes
- [x] Labels, help text, and customer facing messages are reviewed by Docs
- [ ] QE story level testing completed
